### PR TITLE
1. Added autonormal to every material so it can be visually compared …

### DIFF
--- a/ModelMaterials/001_units_s3o_assimp.lua
+++ b/ModelMaterials/001_units_s3o_assimp.lua
@@ -10,6 +10,7 @@ local materials = {
 		shaderOptions = {
 			flashlights   = true,
 			normalmapping = true,
+			autonormal = true,
 		},
 		deferredOptions = {
 			normalmapping = true,


### PR DESCRIPTION
…to handmade normalmaps by toggling the latter off. In this case autonormal kicks in if normalmapping is disabled (`/luarules normalmapping`)

2. Reduced material specular multiplier by a factor of two
3a. Added USE_ROUGHNESS #define flag (now on)
3b. Added roughness from BAR. R.n. roughness is hardcoded to follow sine shape with time as argument. This allows to witness how roughness affects material surfaces.